### PR TITLE
Feature/integrate signup with payment provider

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,7 @@
         "react/jsx-filename-extension": ["error", { "extensions": [".js", ".jsx", ".ts", ".tsx"] }],
         "react/jsx-props-no-spreading": ["off"],
         "react/require-default-props": ["off"],
+        "react/no-array-index-key": ["off"],
         "import/extensions": ["error", "never"],
         "import/no-unresolved": ["off"],
         "max-len": ["error", {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -141,7 +141,6 @@ export default function App() {
       </Container>
       <Footer />
 
-      {userSub && <NotificationSnackbar message='A confirmation link has been sent to your email. Glad to have you onboard ;)' />}
       {isDeleted && <NotificationSnackbar message='You account has been deleted. We hope to see you back soon!' />}
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,8 +20,7 @@ import Subscription from 'components/Subscription';
 import NotificationSnackbar from 'components/NotificationSnackbar';
 
 export default function App() {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const userSub = searchParams.get('user');
+  const [searchParams] = useSearchParams();
   const isDeleted = searchParams.get('isdeleted');
 
   return (

--- a/src/components/GridList.tsx
+++ b/src/components/GridList.tsx
@@ -13,8 +13,8 @@ export default function GridList({ list }: GridListProps) {
       justifyContent={{ xs: 'center', md: 'flex-start' }}
     >
       {
-        list.map((item) => (
-          <Grid item xs='auto'>{item}</Grid>
+        list.map((item, index) => (
+          <Grid item xs='auto' key={`grid-item-${index}`}>{item}</Grid>
         ))
       }
     </Grid>

--- a/src/components/Subscription.tsx
+++ b/src/components/Subscription.tsx
@@ -61,12 +61,13 @@ export default function Subscription() {
         }}
       >
         {
-          Object.entries(SUBSCRIPTIONS).map(([tier, { price, benefits }]) => (
+          Object.entries(SUBSCRIPTIONS).map(([tier, { price, benefits }], index) => (
             <SubscriptionTile
               tier={tier as SubscriptionTier}
               benefits={benefits}
               price={price && `${isYearly ? price.yearly : price.monthly}$ / month`}
               isYearly={isYearly}
+              key={`tile-item-${index}`}
             />
           ))
         }

--- a/src/components/Subscription.tsx
+++ b/src/components/Subscription.tsx
@@ -4,12 +4,12 @@ import FormGroup from '@mui/material/FormGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Switch from '@mui/material/Switch';
 
-import SubscriptionTile, { SubscriptionTier } from 'components/SubscriptionTile';
+import SubscriptionTile from 'components/SubscriptionTile';
+import { SubscriptionTier } from 'libs/subscription';
 
 export const SUBSCRIPTIONS = {
   [SubscriptionTier.FREE]: {
     price: null,
-    priceId: null,
     benefits: [
       'Send up to 3 GB per file',
       'Unlimited number of files',
@@ -22,10 +22,6 @@ export const SUBSCRIPTIONS = {
       monthly: 6,
       yearly: 5,
     },
-    priceId: {
-      monthly: 'price_1KmD1lFJFAGDCGYEbWBkY4hc',
-      yearly: 'price_1KmD1HFJFAGDCGYEFWTjIuIG',
-    },
     benefits: [
       'Coming soon!',
     ],
@@ -34,10 +30,6 @@ export const SUBSCRIPTIONS = {
     price: {
       monthly: 10,
       yearly: 9,
-    },
-    priceId: {
-      monthly: 'price_1KmDFiFJFAGDCGYEpyo3kTjC',
-      yearly: 'price_1KmDDdFJFAGDCGYEsP4hBTO5',
     },
     benefits: [
       'Coming soon!',
@@ -69,12 +61,12 @@ export default function Subscription() {
         }}
       >
         {
-          Object.entries(SUBSCRIPTIONS).map(([tier, { price, priceId, benefits }]) => (
+          Object.entries(SUBSCRIPTIONS).map(([tier, { price, benefits }]) => (
             <SubscriptionTile
               tier={tier as SubscriptionTier}
-              price={price && `${isYearly ? price.yearly : price.monthly}$ / month`}
-              priceId={priceId && (isYearly ? priceId.yearly : priceId.monthly)}
               benefits={benefits}
+              price={price && `${isYearly ? price.yearly : price.monthly}$ / month`}
+              isYearly={isYearly}
             />
           ))
         }

--- a/src/components/SubscriptionTile.tsx
+++ b/src/components/SubscriptionTile.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Box from '@mui/material/Box';
-import Input from '@mui/material/Input';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import Divider from '@mui/material/Divider';
@@ -14,27 +13,26 @@ interface SubscriptionProps {
   tier: SubscriptionTier;
   benefits: string[];
   price: string | null;
-  priceId: string | null;
+  isYearly: boolean;
 }
 
-const PAID_SUBSCRIBE_URL = () => `https://${settings.apiDomainName}/subscription/create-checkout-session`;
+interface SubscriptionUrlParams {
+  tier: SubscriptionTier;
+  yearly: boolean;
+}
 
-const FREE_SUBSCRIBE_URL = () => {
-  const params = {
-    client_id: authenticationSettings.userPoolWebClientId,
-    response_type: 'code',
-    scope: ['openid', 'email', 'profile'].join(' '),
-    redirect_uri: `https://${settings.siteDomainName}/get`,
-  };
+/**
+ * Generate subscription URL
+ */
+const SUBSCRIPTION_URL = (params: SubscriptionUrlParams) => {
+  const searchParams = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => value && searchParams.set(key, value));
 
-  const cognitoHostedUIUrl = new URL('signup', `https://${settings.authDomainName}`);
-  Object.entries(params).forEach(([key, value]) => cognitoHostedUIUrl.searchParams.set(key, value));
-
-  return cognitoHostedUIUrl.href;
+  return `/signup?${searchParams.toString()}`;
 };
 
-export default function Subscription({
-  tier, benefits, price, priceId,
+export default function SubscriptionTile({
+  tier, benefits, price, isYearly,
 }: SubscriptionProps) {
   const sx = {
     backgroundColor: 'white',
@@ -69,42 +67,21 @@ export default function Subscription({
     </>
   );
 
-  if (price && priceId) {
-    return (
-      <Box
-        component='form'
-        action={PAID_SUBSCRIBE_URL()}
-        method='POST'
-        sx={sx}
-      >
-        {content}
-        <Divider variant='middle' flexItem sx={{ marginTop: 'auto' }} />
-        <Typography variant='h5' fontWeight='bold' sx={{ marginY: 2 }}>{price}</Typography>
-
-        <Input type='hidden' name='priceId' value={priceId} />
-        <Button
-          disabled // TODO remove once subscription is available
-          type='submit'
-          variant='contained'
-          size='large'
-          color='secondary'
-          fullWidth
-          sx={{
-            fontWeight: 'bold',
-            marginTop: 'auto',
-          }}
-        >
-          Join
-        </Button>
-      </Box>
-    );
-  }
-
   return (
     <Box sx={sx}>
       {content}
+
+      {
+        price && (
+          <>
+            <Divider variant='middle' flexItem sx={{ marginTop: 'auto' }} />
+            <Typography variant='h5' fontWeight='bold' sx={{ marginY: 2 }}>{price}</Typography>
+          </>
+        )
+      }
+
       <Button
-        href={FREE_SUBSCRIBE_URL()}
+        href={SUBSCRIPTION_URL({ tier, yearly: isYearly })}
         variant='contained'
         size='large'
         color='secondary'
@@ -114,7 +91,7 @@ export default function Subscription({
           marginTop: 'auto',
         }}
       >
-        Create account
+        {price ? 'Join' : 'Create account'}
       </Button>
     </Box>
   );

--- a/src/components/SubscriptionTile.tsx
+++ b/src/components/SubscriptionTile.tsx
@@ -8,13 +8,7 @@ import Divider from '@mui/material/Divider';
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import settings, { authentication as authenticationSettings } from 'settings';
-
-export enum SubscriptionTier {
-  FREE = 'Free',
-  STANDARD = 'Standard',
-  PREMIUM = 'Premium',
-}
+import { SubscriptionTier } from 'libs/subscription';
 
 interface SubscriptionProps {
   tier: SubscriptionTier;

--- a/src/components/SubscriptionTile.tsx
+++ b/src/components/SubscriptionTile.tsx
@@ -55,8 +55,12 @@ export default function SubscriptionTile({
       <Typography variant='h3' fontWeight='bold'>{tier}</Typography>
       <Box sx={{ minHeight: '20rem', marginY: 4 }}>
         {
-          benefits.map((benefit) => (
-            <Typography variant='body1' sx={{ lineHeight: 2 }}>
+          benefits.map((benefit, index) => (
+            <Typography
+              variant='body1'
+              sx={{ lineHeight: 2 }}
+              key={`benefit-item-${index}`}
+            >
               <FontAwesomeIcon icon={faCheck} />
               &nbsp;&nbsp;&nbsp;
               {benefit}

--- a/src/components/authentication/AuthenticationBase.tsx
+++ b/src/components/authentication/AuthenticationBase.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import Container from '@mui/material/Container';
+import Box from '@mui/material/Box';
+
+import Logo from 'components/Logo';
+
+export default function AuthenticationBase({ children }: { children: React.ReactNode }) {
+  return (
+    <Container
+      maxWidth={false}
+      disableGutters
+      sx={{
+        backgroundColor: 'honey.main',
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        flexWrap: 'no-wrap',
+        justifyContent: 'flex-start',
+        alignItems: 'center',
+      }}
+    >
+      <Box sx={{ marginY: 4 }}>
+        <Logo width='35vh' />
+      </Box>
+
+      <Box
+        sx={{
+          backgroundColor: 'white',
+          padding: 4,
+          marginBottom: 4,
+          minWidth: '15rem',
+          width: { xs: '80vw', md: '27rem' },
+          minHeight: '10rem',
+          border: '1px solid grey',
+          borderRadius: 2,
+        }}
+      >
+        {children}
+      </Box>
+    </Container>
+  );
+}

--- a/src/components/authentication/AuthenticationForm.tsx
+++ b/src/components/authentication/AuthenticationForm.tsx
@@ -1,52 +1,26 @@
 import React from 'react';
-import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
-
-import Logo from 'components/Logo';
+import AuthenticationBase from 'components/authentication/AuthenticationBase';
 
 export default function AuthenticationForm({
   children, handleSubmit,
 }: { children: React.ReactNode, handleSubmit: React.FormEventHandler }) {
   return (
-    <Container
-      maxWidth={false}
-      disableGutters
-      sx={{
-        backgroundColor: 'honey.main',
-        minHeight: '100vh',
-        display: 'flex',
-        flexDirection: 'column',
-        flexWrap: 'no-wrap',
-        justifyContent: 'flex-start',
-        alignItems: 'center',
-      }}
-    >
-      <Box sx={{ marginY: 4 }}>
-        <Logo width='35vh' />
-      </Box>
-
+    <AuthenticationBase>
       <Box
         component='form'
         autoComplete='on'
         onSubmit={handleSubmit}
         sx={{
-          backgroundColor: 'white',
-          padding: 4,
-          marginBottom: 4,
-          minWidth: '15rem',
-          width: { xs: '80vw', md: '27rem' },
-          minHeight: '15rem',
           display: 'flex',
           flexDirection: 'column',
           flexWrap: 'no-wrap',
           justifyContent: 'flex-start',
           alignItems: 'center',
-          border: '1px solid grey',
-          borderRadius: 2,
         }}
       >
         {children}
       </Box>
-    </Container>
+    </AuthenticationBase>
   );
 }

--- a/src/components/authentication/LogIn.tsx
+++ b/src/components/authentication/LogIn.tsx
@@ -220,7 +220,7 @@ export default function LogIn() {
       />
 
       <Typography variant='caption' sx={{ marginY: 2 }}>
-        <Link href='/resetpassword' color='inherit' title='Forgot your password'>Forgot your password?</Link>
+        <Link href='/resetpassword' color='inherit'>Forgot your password?</Link>
       </Typography>
 
       {
@@ -231,7 +231,7 @@ export default function LogIn() {
             onClick={handleResendConfirmation}
             sx={{ marginY: 2 }}
           >
-            Resend confirmation email?
+            Resend confirmation link?
           </Button>
         )
       }

--- a/src/components/authentication/LogIn.tsx
+++ b/src/components/authentication/LogIn.tsx
@@ -11,6 +11,7 @@ import EmailIcon from '@mui/icons-material/Email';
 import LockIcon from '@mui/icons-material/Lock';
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
+import LoginIcon from '@mui/icons-material/Login';
 
 import NotificationSnackbar from 'components/NotificationSnackbar';
 import AuthenticationForm from 'components/authentication/AuthenticationForm';
@@ -240,6 +241,7 @@ export default function LogIn() {
         type='submit'
         size='large'
         fullWidth
+        endIcon={<LoginIcon />}
         loading={state.isLoading}
         sx={{
           marginY: 2,

--- a/src/components/authentication/ResetPassword.tsx
+++ b/src/components/authentication/ResetPassword.tsx
@@ -108,7 +108,7 @@ export default function ResetPassword() {
 
       <Typography variant='caption'>
         Create an account instead?&nbsp;
-        <Link href='/signup' color='inherit' title='Sign up'>Sign up</Link>
+        <Link href='/signup' color='inherit'>Sign up</Link>
         .
       </Typography>
 

--- a/src/components/authentication/ResetPasswordCode.tsx
+++ b/src/components/authentication/ResetPasswordCode.tsx
@@ -246,7 +246,7 @@ export default function ResetPasswordCode() {
         .
       </Typography>
 
-      {errorState.isMaximumAttemptsExceededError && <NotificationSnackbar message='Maximum number of attempts exceeded. Please wait and retry later.' severity='error' />}
+      {errorState.isMaximumAttemptsExceededError && <NotificationSnackbar message='Attempt limit exceeded, please try after some time.' severity='error' />}
       {errorState.isNetworkError && <NotificationSnackbar message='Something is wrong with the network. Please check your internet connection.' severity='error' />}
     </AuthenticationForm>
   );

--- a/src/components/authentication/SignUp.tsx
+++ b/src/components/authentication/SignUp.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useSearchParams, useNavigate } from 'react-router-dom';
 import LoadingButton from '@mui/lab/LoadingButton';
 import Link from '@mui/material/Link';
 import TextField from '@mui/material/TextField';
@@ -20,6 +20,8 @@ import { UsernameExistsException, InvalidPasswordException, NetworkError } from 
 import NotificationSnackbar from 'components/NotificationSnackbar';
 import AuthenticationForm from 'components/authentication/AuthenticationForm';
 import { SUBSCRIPTIONS } from 'components/Subscription';
+
+import settings from 'settings';
 
 
 interface SignUpState {
@@ -45,7 +47,19 @@ const INITIAL_ERROR_STATE = {
 };
 
 export default function SignUp() {
-  const [state, setState] = useState<SignUpState>(INITIAL_STATE);
+  const [searchParams] = useSearchParams();
+  const tier = searchParams.get('tier') as SubscriptionTier;
+  const isYearly = searchParams.get('yearly') === 'true';
+
+  let priceId: string | null = null;
+  if (tier) {
+    priceId = getPriceId(tier, isYearly);
+  }
+
+  const [state, setState] = useState<SignUpState>({
+    ...INITIAL_STATE,
+    ...(tier && { subscriptionTier: tier }),
+  });
   const [errorState, setErrorState] = useState(INITIAL_ERROR_STATE);
 
   const navigate = useNavigate();
@@ -231,7 +245,7 @@ export default function SignUp() {
           borderRadius: 2,
         }}
       >
-        Sign up
+        {priceId ? 'Continue' : 'Sign up'}
       </LoadingButton>
 
       <Typography variant='caption'>

--- a/src/components/authentication/SignUp.tsx
+++ b/src/components/authentication/SignUp.tsx
@@ -240,9 +240,9 @@ export default function SignUp() {
 
       <Typography variant='caption' sx={{ marginY: 2 }}>
         By creating an account, you agree to our&nbsp;
-        <Link href='/terms' target='_blank' color='inherit' title='Terms of Service' aria-label='go to terms of service'>Terms</Link>
+        <Link href='/terms' target='_blank' color='inherit' aria-label='go to terms of service'>Terms</Link>
         &nbsp;and&nbsp;
-        <Link href='/privacy' target='_blank' color='inherit' title='Privacy policy' aria-label='go to privacy policy'>Privacy Policy</Link>
+        <Link href='/privacy' target='_blank' color='inherit' aria-label='go to privacy policy'>Privacy Policy</Link>
         .
       </Typography>
 

--- a/src/components/authentication/SignUp.tsx
+++ b/src/components/authentication/SignUp.tsx
@@ -12,7 +12,6 @@ import EmailIcon from '@mui/icons-material/Email';
 import LockIcon from '@mui/icons-material/Lock';
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 
 import AuthenticationClient from 'libs/authentication';
 import { SubscriptionTier, parseTier } from 'libs/subscription';
@@ -252,7 +251,6 @@ export default function SignUp() {
         type='submit'
         size='large'
         fullWidth
-        endIcon={state.subscriptionTier === SubscriptionTier.FREE ? null : <ArrowForwardIcon />}
         loading={state.isLoading}
         sx={{
           marginY: 2,
@@ -260,7 +258,7 @@ export default function SignUp() {
           borderRadius: 2,
         }}
       >
-        {state.subscriptionTier === SubscriptionTier.FREE ? 'Sign up' : 'Continue'}
+        Sign up
       </LoadingButton>
 
       <Typography variant='caption'>

--- a/src/components/authentication/SignUp.tsx
+++ b/src/components/authentication/SignUp.tsx
@@ -131,6 +131,11 @@ export default function SignUp() {
         subscriptionFormRef.current!.submit();
       }
     } catch (error) {
+      setState((prevState) => ({
+        ...prevState,
+        isLoading: false,
+      }));
+
       if (error instanceof UsernameExistsException) {
         setErrorState((prevState) => ({
           ...prevState,
@@ -149,11 +154,6 @@ export default function SignUp() {
       } else {
         console.error(error);
       }
-    } finally {
-      setState((prevState) => ({
-        ...prevState,
-        isLoading: false,
-      }));
     }
   };
 

--- a/src/components/authentication/SignUp.tsx
+++ b/src/components/authentication/SignUp.tsx
@@ -259,7 +259,7 @@ export default function SignUp() {
           type='submit'
           size='large'
           fullWidth
-          endIcon={state.priceId ? <ArrowForwardIcon /> : null}
+          endIcon={state.subscriptionTier === SubscriptionTier.FREE ? null : <ArrowForwardIcon />}
           loading={state.isLoading}
           sx={{
             marginY: 2,
@@ -267,7 +267,7 @@ export default function SignUp() {
             borderRadius: 2,
           }}
         >
-          {state.priceId ? 'Continue' : 'Sign up'}
+          {state.subscriptionTier === SubscriptionTier.FREE ? 'Sign up' : 'Continue'}
         </LoadingButton>
 
         <Typography variant='caption'>

--- a/src/components/authentication/SignUp.tsx
+++ b/src/components/authentication/SignUp.tsx
@@ -14,12 +14,12 @@ import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
 
 import AuthenticationClient from 'libs/authentication';
+import { SubscriptionTier, getPriceId } from 'libs/subscription';
 import { UsernameExistsException, InvalidPasswordException, NetworkError } from 'libs/errors';
 
 import NotificationSnackbar from 'components/NotificationSnackbar';
 import AuthenticationForm from 'components/authentication/AuthenticationForm';
 import { SUBSCRIPTIONS } from 'components/Subscription';
-import { SubscriptionTier } from 'components/SubscriptionTile';
 
 
 interface SignUpState {

--- a/src/components/authentication/SignUp.tsx
+++ b/src/components/authentication/SignUp.tsx
@@ -50,9 +50,19 @@ const INITIAL_ERROR_STATE = {
   isNetworkError: false,
 };
 
+const parseTier = (rawTier: string | null): SubscriptionTier | null => {
+  if (!rawTier) {
+    return null;
+  }
+
+  return Object.entries(SubscriptionTier)
+    .find(([, v]: [string, SubscriptionTier]) => rawTier.toLowerCase() === v.toLowerCase())
+    ?.[1] ?? null;
+};
+
 export default function SignUp() {
-  const tier = searchParams.get('tier') as SubscriptionTier;
   const [searchParams, setSearchParams] = useSearchParams();
+  const tier = parseTier(searchParams.get('tier'));
   const isYearly = searchParams.get('yearly') === 'true';
 
   const [errorState, setErrorState] = useState(INITIAL_ERROR_STATE);

--- a/src/components/authentication/SignUp.tsx
+++ b/src/components/authentication/SignUp.tsx
@@ -192,7 +192,7 @@ export default function SignUp() {
         ref={subscriptionFormRef}
       >
         <Input type='hidden' name='email' value={state.email} />
-        <Input type='hidden' name='priceId' value={state.priceId} />
+        <Input type='hidden' name='priceId' value={state.priceId ?? ''} />
       </Box>
 
       <AuthenticationForm handleSubmit={handleSubmit}>

--- a/src/components/authentication/SignUp.tsx
+++ b/src/components/authentication/SignUp.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import LoadingButton from '@mui/lab/LoadingButton';
 import Box from '@mui/material/Box';
@@ -51,8 +51,8 @@ const INITIAL_ERROR_STATE = {
 };
 
 export default function SignUp() {
-  const [searchParams] = useSearchParams();
   const tier = searchParams.get('tier') as SubscriptionTier;
+  const [searchParams, setSearchParams] = useSearchParams();
   const isYearly = searchParams.get('yearly') === 'true';
 
   const [errorState, setErrorState] = useState(INITIAL_ERROR_STATE);
@@ -73,11 +73,6 @@ export default function SignUp() {
       setErrorState((prevState) => ({
         ...prevState,
         isEmailError: false,
-      }));
-    } else if (prop === 'subscriptionTier') {
-      setState((prevState) => ({
-        ...prevState,
-        priceId: getPriceId(event.target.value as SubscriptionTier, isYearly),
       }));
     } else if (prop === 'password' && errorState.isPasswordError) {
       // When in password error state, help user by showing when password becomes valid
@@ -156,6 +151,26 @@ export default function SignUp() {
       }
     }
   };
+
+  useEffect(
+    () => {
+      setState((prevState) => ({
+        ...prevState,
+        priceId: getPriceId(state.subscriptionTier as SubscriptionTier, isYearly),
+      }));
+
+      setSearchParams(
+        new URLSearchParams({
+          tier: state.subscriptionTier,
+          yearly: isYearly.toString(),
+        }),
+        { replace: true },
+      );
+    },
+    [
+      state.subscriptionTier,
+    ],
+  );
 
   return (
     <>

--- a/src/components/authentication/SignUp.tsx
+++ b/src/components/authentication/SignUp.tsx
@@ -12,6 +12,7 @@ import EmailIcon from '@mui/icons-material/Email';
 import LockIcon from '@mui/icons-material/Lock';
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 
 import AuthenticationClient from 'libs/authentication';
 import { SubscriptionTier, getPriceId } from 'libs/subscription';
@@ -238,6 +239,7 @@ export default function SignUp() {
         type='submit'
         size='large'
         fullWidth
+        endIcon={priceId ? <ArrowForwardIcon /> : null}
         loading={state.isLoading}
         sx={{
           marginY: 2,

--- a/src/components/authentication/SignUpConfirmation.tsx
+++ b/src/components/authentication/SignUpConfirmation.tsx
@@ -38,48 +38,52 @@ export default function SignUpConfirmation() {
 
   return (
     <AuthenticationBase>
-      <Typography variant='body1' sx={{ marginY: 2 }}>
-        A confirmation link has been sent to your email <strong>{state.email}</strong>.
-        <br />
-        <br />
-        Glad to have you on board 😉!
-      </Typography>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          flexWrap: 'no-wrap',
+          justifyContent: 'flex-start',
+          alignItems: 'center',
+        }}
+      >
+        <Typography variant='body1' sx={{ marginY: 2 }}>
+          A confirmation link has been sent to your email <strong>{state.email}</strong>.
+          <br />
+          <br />
+          Glad to have you on board 🥳🎉!
+        </Typography>
 
-      {
-        state.priceId && (
-          <Box
-            component='form'
-            action={`https://${settings.apiDomainName}/subscription/create-checkout-session`}
-            method='POST'
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              flexWrap: 'no-wrap',
-              justifyContent: 'flex-start',
-              alignItems: 'center',
-              width: '100%',
-            }}
-          >
-            <Input type='hidden' name='priceId' value={state.priceId} />
-            <Input type='hidden' name='email' value={state.email} />
-            <Input type='hidden' name='cancelUrl' value={window.location.href} />
-
-            <LoadingButton
-              variant='contained'
-              type='submit'
-              size='large'
-              fullWidth
-              loading={state.isLoading}
-              sx={{
-                marginY: 2,
-                borderRadius: 2,
-              }}
+        {
+          state.priceId && (
+            <Box
+              component='form'
+              action={`https://${settings.apiDomainName}/subscription/create-checkout-session`}
+              method='POST'
+              sx={{ width: '100%' }}
             >
-              Continue to subscription
-            </LoadingButton>
-          </Box>
-        )
-      }
+              <Input type='hidden' name='priceId' value={state.priceId} />
+              <Input type='hidden' name='email' value={state.email} />
+              <Input type='hidden' name='cancelUrl' value={window.location.href} />
+
+              <LoadingButton
+                variant='contained'
+                type='submit'
+                size='large'
+                fullWidth
+                loading={state.isLoading}
+                sx={{
+                  marginY: 2,
+                  borderRadius: 2,
+                }}
+              >
+                Continue to subscription
+              </LoadingButton>
+            </Box>
+          )
+        }
+      </Box>
+
     </AuthenticationBase>
   );
 }

--- a/src/components/authentication/SignUpConfirmation.tsx
+++ b/src/components/authentication/SignUpConfirmation.tsx
@@ -7,6 +7,7 @@ import Input from '@mui/material/Input';
 import Button from '@mui/material/Button';
 import LoadingButton from '@mui/lab/LoadingButton';
 import Typography from '@mui/material/Typography';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 
 import NotificationSnackbar from 'components/NotificationSnackbar';
 import AuthenticationBase from 'components/authentication/AuthenticationBase';
@@ -87,6 +88,7 @@ export default function SignUpConfirmation() {
                 size='large'
                 fullWidth
                 loading={state.isLoading}
+                endIcon={<ArrowForwardIcon />}
                 sx={{
                   marginY: 2,
                   borderRadius: 2,

--- a/src/components/authentication/SignUpConfirmation.tsx
+++ b/src/components/authentication/SignUpConfirmation.tsx
@@ -137,6 +137,24 @@ export default function SignUpConfirmation() {
           )
         }
 
+        {
+          !state.priceId && (
+            <Button
+              variant='contained'
+              size='large'
+              href='/account'
+              fullWidth
+              endIcon={<ArrowForwardIcon />}
+              sx={{
+                marginY: 2,
+                borderRadius: 2,
+              }}
+            >
+              Continue to your account page
+            </Button>
+          )
+        }
+
         <Button variant='text' size='small' onClick={handleResendConfirmation}>Resend confirmation link?</Button>
       </Box>
 

--- a/src/components/authentication/SignUpConfirmation.tsx
+++ b/src/components/authentication/SignUpConfirmation.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable react/jsx-one-expression-per-line */
+
+import React, { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import Input from '@mui/material/Input';
+import LoadingButton from '@mui/lab/LoadingButton';
+import Typography from '@mui/material/Typography';
+
+import AuthenticationBase from 'components/authentication/AuthenticationBase';
+import { parseTier, getPriceId } from 'libs/subscription';
+
+import settings from 'settings';
+
+interface SignUpConfirmationState {
+  email: string;
+  priceId: string | null;
+  isLoading: boolean;
+}
+
+const INITIAL_STATE: SignUpConfirmationState = {
+  email: '',
+  priceId: null,
+  isLoading: false,
+};
+
+export default function SignUpConfirmation() {
+  const [searchParams] = useSearchParams();
+  const email = searchParams.get('email') ?? '';
+  const tier = parseTier(searchParams.get('tier'));
+  const isYearly = searchParams.get('yearly') === 'true';
+
+  const [state] = useState<SignUpConfirmationState>({
+    ...INITIAL_STATE,
+    ...(tier && { priceId: getPriceId(tier, isYearly) }),
+    email,
+  });
+
+  return (
+    <AuthenticationBase>
+      <Typography variant='body1' sx={{ marginY: 2 }}>
+        A confirmation link has been sent to your email <strong>{state.email}</strong>.
+        <br />
+        <br />
+        Glad to have you on board 😉!
+      </Typography>
+
+      {
+        state.priceId && (
+          <Box
+            component='form'
+            action={`https://${settings.apiDomainName}/subscription/create-checkout-session`}
+            method='POST'
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              flexWrap: 'no-wrap',
+              justifyContent: 'flex-start',
+              alignItems: 'center',
+              width: '100%',
+            }}
+          >
+            <Input type='hidden' name='priceId' value={state.priceId} />
+            <Input type='hidden' name='email' value={state.email} />
+            <Input type='hidden' name='cancelUrl' value={window.location.href} />
+
+            <LoadingButton
+              variant='contained'
+              type='submit'
+              size='large'
+              fullWidth
+              loading={state.isLoading}
+              sx={{
+                marginY: 2,
+                borderRadius: 2,
+              }}
+            >
+              Continue to subscription
+            </LoadingButton>
+          </Box>
+        )
+      }
+    </AuthenticationBase>
+  );
+}

--- a/src/components/authentication/SignUpConfirmation.tsx
+++ b/src/components/authentication/SignUpConfirmation.tsx
@@ -76,6 +76,12 @@ export default function SignUpConfirmation() {
               component='form'
               action={`https://${settings.apiDomainName}/subscription/create-checkout-session`}
               method='POST'
+              onSubmit={() => {
+                setState((prevState) => ({
+                  ...prevState,
+                  isLoading: true,
+                }));
+              }}
               sx={{ width: '100%' }}
             >
               <Input type='hidden' name='priceId' value={state.priceId} />

--- a/src/components/authentication/SignUpConfirmation.tsx
+++ b/src/components/authentication/SignUpConfirmation.tsx
@@ -4,10 +4,13 @@ import React, { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Input from '@mui/material/Input';
+import Button from '@mui/material/Button';
 import LoadingButton from '@mui/lab/LoadingButton';
 import Typography from '@mui/material/Typography';
 
+import NotificationSnackbar from 'components/NotificationSnackbar';
 import AuthenticationBase from 'components/authentication/AuthenticationBase';
+import AuthenticationClient from 'libs/authentication';
 import { parseTier, getPriceId } from 'libs/subscription';
 
 import settings from 'settings';
@@ -35,6 +38,18 @@ export default function SignUpConfirmation() {
     ...(tier && { priceId: getPriceId(tier, isYearly) }),
     email,
   });
+  const [resendConfirmation, setResendConfirmation] = useState(false);
+
+  const handleResendConfirmation = async () => {
+    try {
+      setResendConfirmation(true);
+      await AuthenticationClient.resendConfirmationEmail({ email: state.email });
+    } catch (error) {
+      // Noop
+    } finally {
+      setTimeout(() => setResendConfirmation(false), 3000);
+    }
+  };
 
   return (
     <AuthenticationBase>
@@ -82,8 +97,11 @@ export default function SignUpConfirmation() {
             </Box>
           )
         }
+
+        <Button variant='text' size='small' onClick={handleResendConfirmation}>Resend confirmation link?</Button>
       </Box>
 
+      {resendConfirmation && <NotificationSnackbar message='A new confirmation link has been sent to your email' />}
     </AuthenticationBase>
   );
 }

--- a/src/components/authentication/index.ts
+++ b/src/components/authentication/index.ts
@@ -1,4 +1,5 @@
 export { default as SignUp } from './SignUp';
+export { default as SignUpConfirmation } from './SignUpConfirmation';
 export { default as LogIn } from './LogIn';
 export { default as ResetPassword } from './ResetPassword';
 export { default as ResetPasswordCode } from './ResetPasswordCode';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,7 +18,7 @@ import Terms from 'components/Terms';
 import Privacy from 'components/Privacy';
 import ErrorDisplay from 'components/ErrorDisplay';
 import {
-  SignUp, LogIn, ResetPassword, ResetPasswordCode,
+  SignUp, SignUpConfirmation, LogIn, ResetPassword, ResetPasswordCode,
 } from 'components/authentication';
 
 ReactDOM.render(
@@ -30,6 +30,7 @@ ReactDOM.render(
           <Route path='/' element={<App />} />
           <Route path=':fileId' element={<FileFrame />} />
           <Route path='signup' element={<SignUp />} />
+          <Route path='confirmation' element={<SignUpConfirmation />} />
           <Route path='login' element={<LogIn />} />
           <Route path='forgotpassword' element={<ResetPassword />} />
           <Route path='resetpassword' element={<ResetPassword />} />

--- a/src/libs/authentication.ts
+++ b/src/libs/authentication.ts
@@ -14,7 +14,7 @@ import {
   NetworkError,
   NoCurrentUserError,
 } from 'libs/errors';
-import { SubscriptionTier } from 'components/SubscriptionTile';
+import { SubscriptionTier } from 'libs/subscription';
 import { authentication as authenticationSettings } from 'settings';
 
 Amplify.configure({

--- a/src/libs/subscription.ts
+++ b/src/libs/subscription.ts
@@ -1,0 +1,26 @@
+export enum SubscriptionTier {
+  FREE = 'Free',
+  STANDARD = 'Standard',
+  PREMIUM = 'Premium',
+}
+
+const PRICE_ID = {
+  [SubscriptionTier.FREE]: {
+    monthly: null,
+    yearly: null,
+  },
+  [SubscriptionTier.STANDARD]: {
+    monthly: 'price_1KmD1lFJFAGDCGYEbWBkY4hc',
+    yearly: 'price_1KmD1HFJFAGDCGYEFWTjIuIG',
+  },
+  [SubscriptionTier.PREMIUM]: {
+    monthly: 'price_1KmDFiFJFAGDCGYEpyo3kTjC',
+    yearly: 'price_1KmDDdFJFAGDCGYEsP4hBTO5',
+  },
+};
+
+export function getPriceId(tier: SubscriptionTier, isYearly: boolean): string | null {
+  return isYearly === true
+    ? PRICE_ID[tier].yearly
+    : PRICE_ID[tier].monthly;
+}

--- a/src/libs/subscription.ts
+++ b/src/libs/subscription.ts
@@ -19,6 +19,16 @@ const PRICE_ID = {
   },
 };
 
+export function parseTier(rawTier: string | null): SubscriptionTier | null {
+  if (!rawTier) {
+    return null;
+  }
+
+  return Object.entries(SubscriptionTier)
+    .find(([, v]: [string, SubscriptionTier]) => rawTier.toLowerCase() === v.toLowerCase())
+    ?.[1] ?? null;
+}
+
 export function getPriceId(tier: SubscriptionTier, isYearly: boolean): string | null {
   return isYearly === true
     ? PRICE_ID[tier].yearly


### PR DESCRIPTION
On sign-up, a confirmation page (see screenshot) is displayed.

- If paid subscription, a button to continue to subscription payment provider is displayed, which will call the API to generate a checkout session for the user:

<img width="721" alt="image" src="https://user-images.githubusercontent.com/40524083/172326455-24c6902c-c690-489e-b6f2-5e2d8ea7a509.png">

- If free subscription, a button to continue to user account page is displayed.

<img width="999" alt="image" src="https://user-images.githubusercontent.com/40524083/174095255-792e9918-6f94-409e-b912-cbb5d6cd777f.png">

Users have the possibility to re-request a confirmation link.